### PR TITLE
add logit as param for request

### DIFF
--- a/models.go
+++ b/models.go
@@ -59,6 +59,10 @@ type CompletionRequest struct {
 	// Whether to stream back results or not. Don't set this value in the request yourself
 	// as it will be overriden depending on if you use CompletionStream or Completion methods.
 	Stream bool `json:"stream,omitempty"`
+
+	// OAI - Modify the likelihood of specified tokens appearing in the
+	//       completion.
+	LogitBias *map[string]float64 `json:"logit_bias" binding:"omitempty"`
 }
 
 // LogprobResult represents logprob result of Choice


### PR DESCRIPTION
Needed to allow test cases in gooseai/convey-bridge to run test cases on logit bias.